### PR TITLE
psi_chapeau pas au carre

### DIFF
--- a/ch2.qmd
+++ b/ch2.qmd
@@ -15,7 +15,7 @@ L'estimateur est dit *sans biais* s'il est de biais nul.
 - Le risque quadratique de $\hat\theta$ est la quantité $\mathbb{E}_{\theta}[ |\hat{\theta}- \theta|^2]$. 
 :::
 
-En pratique, on peut vouloir estimer non pas $\theta$ lui-même, mais un paramètre $\psi = \psi_\theta$ qui dépend de $\theta$, comme $\cos(\theta)$ ou $|\theta|$ par exemple. Dans ce cas, si $\hat{\psi}$ est un estimateur de $\psi$ alors le biais est défini par $\mathbb{E}_\theta[\hat{\psi} - \psi_\theta]$ et le risque quadratique par $\mathbb{E}_\theta [ |\hat\psi^2 - \psi_\theta|^2]$. 
+En pratique, on peut vouloir estimer non pas $\theta$ lui-même, mais un paramètre $\psi = \psi_\theta$ qui dépend de $\theta$, comme $\cos(\theta)$ ou $|\theta|$ par exemple. Dans ce cas, si $\hat{\psi}$ est un estimateur de $\psi$ alors le biais est défini par $\mathbb{E}_\theta[\hat{\psi} - \psi_\theta]$ et le risque quadratique par $\mathbb{E}_\theta [ |\hat\psi - \psi_\theta|^2]$. 
 
 La dépendance du risque  quadratique vis à vis de la taille de l'échantillon est une question importante : pour une suite d'expériences donnée, quelles sont les meilleures vitesses envisageables, et comment les obtenir ?
 


### PR DESCRIPTION
J'ai enlevé le carré à psi_chapeau dans la formule du Risque Quadratique.